### PR TITLE
allow directory name in filepath

### DIFF
--- a/filter_gen.py
+++ b/filter_gen.py
@@ -41,7 +41,7 @@ https://en.wikipedia.org/wiki/Digital_filter#Direct_form_II
 
 ################################################################
 # Standard Python libraries.
-import sys, argparse, logging
+import sys, argparse, logging, os
 
 # Set up debugging output.
 # logging.getLogger().setLevel(logging.DEBUG)
@@ -424,6 +424,7 @@ if __name__ == "__main__":
     else:
         filename = args.out
 
+    os.makedirs(os.path.dirname(filename), exist_ok=True) if os.path.dirname(filename) else None
     with open(filename, "w") as stream:
         emit_filter_code(stream, funcname, sos, args.type, args.rate, freqs, args.order, args.language)
 


### PR DESCRIPTION
Currently adding directory name (which is not already present in project path) to output file name results in error.  
<p align="center">
<img width="300" height="170"  alt="output-configuration" src="https://github.com/user-attachments/assets/d36314f6-cd93-4f33-8a9f-5b3fbd1f7c0e" />
<img width="375" height="150" alt="error-msg" src="https://github.com/user-attachments/assets/f79fb2ed-64a0-42d4-af0b-b18f208dfe99" />
</p>

This PR fixes it by using `os.makedirs()`
<p align="center">
<img width="497" height="526" alt="Updated Designer" src="https://github.com/user-attachments/assets/491e3355-e5d2-4776-8c18-095bb44b0c8e" />
</p>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Output directories are now automatically created when needed, preventing file write operations from failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->